### PR TITLE
Add SynMedVision pipeline scaffolding

### DIFF
--- a/synmedvision/.gitignore
+++ b/synmedvision/.gitignore
@@ -1,0 +1,5 @@
+__pycache__/
+*.pyc
+.venv/
+pytest_cache/
+*.npz

--- a/synmedvision/LICENSE
+++ b/synmedvision/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 SynMedVision Contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/synmedvision/Makefile
+++ b/synmedvision/Makefile
@@ -1,0 +1,30 @@
+.PHONY: setup data train_stylegan train_diffusion sample eval report demo docker reproduce
+
+setup:
+python -m venv .venv && . .venv/bin/activate && pip install -e .
+
+data:
+python -m src.cli.prepare --config configs/data.yaml
+
+train_stylegan:
+python -m src.cli.train --config configs/train_stylegan.yaml --model stylegan2
+
+train_diffusion:
+python -m src.cli.train --config configs/train_diffusion_lora.yaml --model diffusion_lora
+
+sample:
+python -m src.cli.generate --n 10000 --out out/samples
+
+eval:
+python -m src.cli.evaluate_images --config configs/eval.yaml
+
+report:
+python -m src.cli.report --out reports/eval_report.html
+
+demo:
+streamlit run src/demo/streamlit_app.py
+
+docker:
+docker build -t synmedvision -f docker/Dockerfile .
+
+reproduce: setup data train_stylegan train_diffusion sample eval report

--- a/synmedvision/README.md
+++ b/synmedvision/README.md
@@ -1,0 +1,69 @@
+# SynMedVision
+
+SynMedVision provides a reproducible reference pipeline for generating, evaluating, and serving synthetic histopathology imagery derived from the PatchCamelyon (PCam) dataset.  The repository contains deterministic data preparation utilities, light-weight baseline training loops for StyleGAN2-ADA and diffusion models with LoRA fine-tuning, and a collection of evaluation and reporting scripts that assess realism, diversity, downstream utility, and privacy risks.
+
+The implementation in this repository focuses on providing an end-to-end skeleton that is fully testable inside a lightweight development container.  Heavy weight training and evaluation logic is abstracted behind clear interfaces so that the core research workflow can be extended with high fidelity models when operating on GPU equipped infrastructure.
+
+## Repository Layout
+
+```
+.
+├── configs/                # YAML configuration files for all CLI entrypoints
+├── docker/                 # Container recipe for GPU execution
+├── src/                    # Implementation modules (data, models, eval, cli, demo)
+├── tests/                  # Unit tests exercising the lightweight pipeline
+├── data/, out/, reports/   # Runtime directories populated by the CLI utilities
+└── Makefile                # Convenience commands mirroring the execution plan
+```
+
+## Quick Start
+
+1. **Create a virtual environment and install dependencies**
+   ```bash
+   make setup
+   ```
+
+2. **Prepare the dataset**
+   ```bash
+   make data
+   ```
+   When PCam assets are not present the command falls back to generating a small synthetic dataset that mimics the structure of the real data.  This behaviour keeps the repository fully testable while still reflecting the real execution flow.
+
+3. **Train baseline models**
+   ```bash
+   make train_stylegan
+   make train_diffusion
+   ```
+   The default implementations create light-weight mock checkpoints so that downstream steps can run deterministically without requiring GPU resources.  Replace the training hooks in `src/models/` with production grade trainers to obtain research quality results.
+
+4. **Generate samples, evaluate, and create a report**
+   ```bash
+   make sample
+   make eval
+   make report
+   ```
+
+5. **Launch the interactive demo**
+   ```bash
+   make demo
+   ```
+
+6. **Full reproducibility**
+   ```bash
+   make reproduce
+   ```
+   This command chains all previous steps to rebuild the complete pipeline from scratch.
+
+## Testing
+
+Run the unit test suite with:
+
+```bash
+pytest
+```
+
+The tests validate image IO helpers, evaluation metrics, and basic privacy analytics to guarantee a stable interface for extending the project.
+
+## License
+
+This project is distributed under the terms of the MIT license.  See [LICENSE](LICENSE).

--- a/synmedvision/configs/controlnet.yaml
+++ b/synmedvision/configs/controlnet.yaml
@@ -1,0 +1,3 @@
+enabled: true
+control_type: "segmentation_mask"
+conditioning_weight: 1.0

--- a/synmedvision/configs/data.yaml
+++ b/synmedvision/configs/data.yaml
@@ -1,0 +1,10 @@
+dataset: "pcam"             # fixed for MVP
+root: "data/pcam"
+img_size: 256
+val_split: 0.15
+test_split: 0.15
+split_by_patient: true
+make_masks: false            # histo masks optional
+normalize:
+  method: "none"             # histo: "macenko" optional later
+output_csv: "data/pcam/manifest.csv"

--- a/synmedvision/configs/eval.yaml
+++ b/synmedvision/configs/eval.yaml
@@ -1,0 +1,28 @@
+real_dir: "data/pcam/val_images"
+synth_dir: "out/samples"
+labels_csv: "data/pcam/val_labels.csv"
+image_size: 256
+
+metrics:
+  realism:
+    kid: true
+    fid: true
+    lpips: true
+  utility:
+    tstr: true
+    trts: true
+    clf_model: "resnet18"
+    epochs: 10
+    batch: 64
+  privacy:
+    nn_features: "resnet50"      # or "clip"
+    nn_tau: 0.28
+    membership_inference: true
+    phash_dup_threshold: 6
+  diversity:
+    feature_entropy: true
+    cov_rank_ratio: true
+
+report:
+  html_out: "reports/pcam_eval.html"
+  sample_grid: true

--- a/synmedvision/configs/train_diffusion_lora.yaml
+++ b/synmedvision/configs/train_diffusion_lora.yaml
@@ -1,0 +1,16 @@
+model: "diffusion_lora"
+base: "stabilityai/sd-1-5"         # latent diffusion base
+resolution: 256
+train_steps: 20000
+batch: 8
+lr: 1e-4
+lora_rank: 8
+class_conditional: true
+mask_conditioning: false
+dp:
+  enabled: true
+  target_epsilon: 10
+  delta: 1e-5
+  max_grad_norm: 1.0
+out_dir: "out/diffusion_lora"
+seed: 123

--- a/synmedvision/configs/train_stylegan.yaml
+++ b/synmedvision/configs/train_stylegan.yaml
@@ -1,0 +1,9 @@
+model: "stylegan2"
+image_size: 256
+batch: 64
+kimgs: 20000
+gpus: 1
+class_conditional: true
+augment: "ada"
+out_dir: "out/stylegan2"
+seed: 123

--- a/synmedvision/docker/Dockerfile
+++ b/synmedvision/docker/Dockerfile
@@ -1,0 +1,7 @@
+FROM pytorch/pytorch:2.3.1-cuda12.1-cudnn8-runtime
+RUN apt-get update && apt-get install -y git ffmpeg libsm6 libxext6 && rm -rf /var/lib/apt/lists/*
+WORKDIR /app
+COPY pyproject.toml /app/
+RUN pip install --upgrade pip && pip install -e .
+COPY . /app
+CMD ["bash"]

--- a/synmedvision/pyproject.toml
+++ b/synmedvision/pyproject.toml
@@ -1,0 +1,19 @@
+[build-system]
+requires = ["setuptools>=61", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "synmedvision"
+version = "0.1.0"
+requires-python = ">=3.10"
+dependencies = [
+  "torch", "torchvision", "pytorch-lightning",
+  "diffusers", "accelerate", "transformers",
+  "lpips", "timm", "scikit-learn", "scipy", "pandas", "numpy",
+  "umap-learn", "matplotlib", "opencv-python", "albumentations", "kornia",
+  "streamlit", "einops",
+  "Pillow", "imagehash", "retrying", "jinja2"
+]
+
+[tool.setuptools.packages.find]
+where = ["src"]

--- a/synmedvision/src/cli/evaluate_images.py
+++ b/synmedvision/src/cli/evaluate_images.py
@@ -1,0 +1,66 @@
+"""CLI for evaluating synthetic image datasets."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Dict
+
+import yaml
+
+from src.common.fs import ensure_dir, write_json
+from src.eval.privacy import privacy_report
+from src.eval.realism import compute_realism_metrics
+from src.eval.utility import compute_utility_metrics
+
+
+def build_argparser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Evaluate generated images")
+    parser.add_argument("--config", required=True)
+    parser.add_argument("--out", default="out/eval_metrics.json")
+    return parser
+
+
+def _load_config(path: str | Path) -> Dict:
+    with Path(path).open("r", encoding="utf-8") as fh:
+        return yaml.safe_load(fh)
+
+
+def evaluate(config_path: str | Path) -> Dict[str, Dict]:
+    config = _load_config(config_path)
+    real_dir = config.get("real_dir")
+    synth_dir = config.get("synth_dir")
+    image_size = int(config.get("image_size", 256))
+
+    metrics_cfg = config.get("metrics", {})
+    results: Dict[str, Dict] = {}
+
+    if metrics_cfg.get("realism", {}).get("kid"):
+        results["realism"] = compute_realism_metrics(real_dir, synth_dir, image_size)
+
+    utility_cfg = metrics_cfg.get("utility", {})
+    if utility_cfg.get("tstr") or utility_cfg.get("trts"):
+        data_root = Path(config.get("labels_csv", "")).parent
+        results["utility"] = compute_utility_metrics(data_root, synth_dir, image_size)
+
+    privacy_cfg = metrics_cfg.get("privacy", {})
+    if privacy_cfg:
+        tau = float(privacy_cfg.get("nn_tau", 0.3))
+        phash_threshold = int(privacy_cfg.get("phash_dup_threshold", 6))
+        results["privacy"] = privacy_report(real_dir, synth_dir, tau, phash_threshold)
+
+    return results
+
+
+def main(args: list[str] | None = None) -> None:
+    parser = build_argparser()
+    parsed = parser.parse_args(args=args)
+    metrics = evaluate(parsed.config)
+    ensure_dir(Path(parsed.out).parent)
+    write_json(metrics, parsed.out)
+    print(json.dumps(metrics, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/synmedvision/src/cli/generate.py
+++ b/synmedvision/src/cli/generate.py
@@ -1,0 +1,117 @@
+"""CLI orchestrator for sampling synthetic images."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+from pathlib import Path
+from typing import Dict, Iterable
+
+from PIL import Image
+
+from src.common.fs import ensure_dir
+from src.models.diffusion.sample import sample_images as diffusion_sample
+from src.models.stylegan2.sample import sample_images as stylegan_sample
+
+
+def _parse_mix(spec: str) -> Dict[str, float]:
+    parts = [p.strip() for p in spec.split(",") if p.strip()]
+    mix: Dict[str, float] = {}
+    for part in parts:
+        label, prob = part.split(":")
+        mix[label.strip()] = float(prob)
+    total = sum(mix.values())
+    if not total:
+        raise ValueError("Class mix probabilities sum to zero")
+    for key in mix:
+        mix[key] /= total
+    return mix
+
+
+def _compute_counts(total: int, mix: Dict[str, float]) -> Dict[str, int]:
+    counts = {label: int(round(total * prob)) for label, prob in mix.items()}
+    diff = total - sum(counts.values())
+    labels = list(mix.keys())
+    idx = 0
+    while diff != 0 and labels:
+        counts[labels[idx % len(labels)]] += 1 if diff > 0 else -1
+        diff = total - sum(counts.values())
+        idx += 1
+    return counts
+
+
+def _validate_png(path: Path) -> bool:
+    try:
+        with Image.open(path) as img:
+            img.load()
+            return img.size == (256, 256) and img.mode == "RGB"
+    except Exception:
+        return False
+
+
+def generate_samples(args: argparse.Namespace) -> Iterable[Path]:
+    mix = _parse_mix(args.class_mix)
+    counts = _compute_counts(args.n, mix)
+    out_dir = ensure_dir(args.out)
+
+    manifest_rows = []
+    generated_paths = []
+
+    for idx, (label, count) in enumerate(counts.items()):
+        if count <= 0:
+            continue
+        seed = args.seed + idx
+        if args.model == "stylegan2":
+            ckpt = args.ckpt or "out/stylegan2/ckpt.pt"
+            paths = stylegan_sample(ckpt_path=ckpt, n=count, class_label=label, out_dir=out_dir, seed=seed)
+        else:
+            base = args.base or "out/diffusion_lora"
+            paths = diffusion_sample(base=base, n=count, class_label=label, steps=args.steps, guidance=args.guidance, seed=seed, out=args.out, mask_path=args.mask_path)
+        for path in paths:
+            manifest_rows.append({
+                "path": str(path),
+                "class": label,
+                "seed": seed,
+                "model": args.model,
+                "params": json.dumps({"steps": args.steps, "guidance": args.guidance}),
+            })
+        generated_paths.extend(paths)
+
+    manifest_path = Path(args.out) / "manifest.csv"
+    with manifest_path.open("w", newline="", encoding="utf-8") as fh:
+        writer = csv.DictWriter(fh, fieldnames=["path", "class", "seed", "model", "params"])
+        writer.writeheader()
+        writer.writerows(manifest_rows)
+
+    invalid = [path for path in generated_paths if not _validate_png(path)]
+    if invalid:
+        raise RuntimeError(f"Invalid images generated: {invalid[:3]}")
+
+    return generated_paths
+
+
+def build_argparser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Generate synthetic images")
+    parser.add_argument("--n", type=int, required=True)
+    parser.add_argument("--class_mix", type=str, required=True)
+    parser.add_argument("--out", type=str, required=True)
+    parser.add_argument("--model", choices=["stylegan2", "diffusion_lora"], default="diffusion_lora")
+    parser.add_argument("--seed", type=int, default=123)
+    parser.add_argument("--steps", type=int, default=30)
+    parser.add_argument("--guidance", type=float, default=7.5)
+    parser.add_argument("--mask_path")
+    parser.add_argument("--ckpt")
+    parser.add_argument("--base")
+    return parser
+
+
+def main(args: list[str] | None = None) -> None:
+    parser = build_argparser()
+    parsed = parser.parse_args(args=args)
+    paths = generate_samples(parsed)
+    print(f"Generated {len(paths)} images to {parsed.out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/synmedvision/src/cli/prepare.py
+++ b/synmedvision/src/cli/prepare.py
@@ -1,0 +1,25 @@
+"""Command line interface for dataset preparation."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from src.data.prepare_pcam import prepare_pcam
+
+
+def build_argparser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Prepare the PCam dataset")
+    parser.add_argument("--config", type=str, required=True, help="Path to the YAML configuration file")
+    return parser
+
+
+def main(args: list[str] | None = None) -> None:
+    parser = build_argparser()
+    parsed = parser.parse_args(args=args)
+    result = prepare_pcam(parsed.config)
+    print(f"Prepared dataset with {len(result['manifest'])} entries")
+
+
+if __name__ == "__main__":
+    main()

--- a/synmedvision/src/cli/report.py
+++ b/synmedvision/src/cli/report.py
@@ -1,0 +1,29 @@
+"""CLI for producing the HTML evaluation report."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from src.common.fs import read_json
+from src.eval.report import generate_report
+
+
+def build_argparser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Generate HTML evaluation report")
+    parser.add_argument("--metrics", default="out/eval_metrics.json")
+    parser.add_argument("--out", default="reports/eval_report.html")
+    return parser
+
+
+def main(args: list[str] | None = None) -> None:
+    parser = build_argparser()
+    parsed = parser.parse_args(args=args)
+    metrics = read_json(parsed.metrics) if Path(parsed.metrics).exists() else {}
+    path = generate_report(metrics, parsed.out)
+    print(f"Saved report to {path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/synmedvision/src/cli/train.py
+++ b/synmedvision/src/cli/train.py
@@ -1,0 +1,43 @@
+"""Training entrypoints for all supported models."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from typing import Any, Dict
+
+import yaml
+
+from src.models.diffusion.finetune_lora import finetune_lora
+from src.models.stylegan2.train import train_stylegan2
+
+
+def _load_config(path: str | Path) -> Dict[str, Any]:
+    with Path(path).open("r", encoding="utf-8") as fh:
+        return yaml.safe_load(fh)
+
+
+def build_argparser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Train synthetic image generators")
+    parser.add_argument("--config", required=True)
+    parser.add_argument("--model", choices=["stylegan2", "diffusion_lora"], required=True)
+    return parser
+
+
+def main(args: list[str] | None = None) -> None:
+    parser = build_argparser()
+    parsed = parser.parse_args(args=args)
+    config = _load_config(parsed.config)
+
+    if parsed.model == "stylegan2":
+        ckpt = train_stylegan2(config)
+        print(f"Saved StyleGAN2 checkpoint to {ckpt}")
+    elif parsed.model == "diffusion_lora":
+        ckpt = finetune_lora(config)
+        print(f"Saved diffusion LoRA checkpoint to {ckpt}")
+    else:
+        raise ValueError(f"Unsupported model: {parsed.model}")
+
+
+if __name__ == "__main__":
+    main()

--- a/synmedvision/src/common/fs.py
+++ b/synmedvision/src/common/fs.py
@@ -1,0 +1,51 @@
+"""Filesystem helpers used across the pipeline."""
+
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass, asdict
+from pathlib import Path
+from typing import Any, Dict
+
+
+def ensure_dir(path: os.PathLike[str] | str) -> Path:
+    """Create a directory (and parents) if it does not exist."""
+
+    path_obj = Path(path)
+    path_obj.mkdir(parents=True, exist_ok=True)
+    return path_obj
+
+
+def write_json(data: Dict[str, Any], path: os.PathLike[str] | str) -> None:
+    """Write a JSON file with pretty formatting."""
+
+    path_obj = Path(path)
+    ensure_dir(path_obj.parent)
+    with path_obj.open("w", encoding="utf-8") as fh:
+        json.dump(data, fh, indent=2, sort_keys=True)
+
+
+def read_json(path: os.PathLike[str] | str) -> Dict[str, Any]:
+    """Read a JSON file returning a dictionary."""
+
+    with Path(path).open("r", encoding="utf-8") as fh:
+        return json.load(fh)
+
+
+@dataclass
+class RunMetadata:
+    """Container describing a pipeline execution."""
+
+    seed: int
+    git_commit: str
+    configs: Dict[str, str]
+    metrics: Dict[str, float]
+    environment: Dict[str, Any]
+
+    def to_json(self) -> Dict[str, Any]:
+        return asdict(self)
+
+
+def write_run_metadata(metadata: RunMetadata, path: os.PathLike[str] | str) -> None:
+    write_json(metadata.to_json(), path)

--- a/synmedvision/src/common/seed.py
+++ b/synmedvision/src/common/seed.py
@@ -1,0 +1,41 @@
+"""Utilities for reproducible experiments."""
+
+from __future__ import annotations
+
+
+def set_global_seed(seed: int) -> None:
+    """Set all relevant random seeds.
+
+    Parameters
+    ----------
+    seed:
+        The seed value to broadcast across Python, NumPy, and Torch.
+    """
+
+    import os
+    import random
+
+    import numpy as np
+
+    os.environ["PYTHONHASHSEED"] = str(seed)
+    random.seed(seed)
+    np.random.seed(seed)
+
+    try:
+        import torch  # type: ignore
+    except ImportError:  # pragma: no cover
+        torch = None
+
+    if torch is not None:
+        torch.manual_seed(seed)
+        if hasattr(torch, "cuda"):
+            torch.cuda.manual_seed_all(seed)
+            if hasattr(torch.backends, "cudnn"):
+                torch.backends.cudnn.benchmark = False
+                torch.backends.cudnn.deterministic = True
+
+
+def seed_worker(worker_id: int, base_seed: int = 123) -> None:
+    """Helper to seed dataloader workers deterministically."""
+
+    set_global_seed(base_seed + worker_id)

--- a/synmedvision/src/data/prepare_pcam.py
+++ b/synmedvision/src/data/prepare_pcam.py
@@ -1,0 +1,170 @@
+"""Data preparation utilities for the PatchCamelyon dataset."""
+
+from __future__ import annotations
+
+import csv
+import json
+import random
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, List, Tuple
+
+import numpy as np
+import yaml
+from PIL import Image
+
+from src.common.fs import ensure_dir, write_json
+from src.common.seed import set_global_seed
+
+
+@dataclass
+class DataConfig:
+    dataset: str
+    root: str
+    img_size: int
+    val_split: float
+    test_split: float
+    split_by_patient: bool
+    make_masks: bool
+    normalize: Dict[str, str]
+    output_csv: str
+
+
+CLASSES = ["normal", "tumor"]
+
+
+def load_config(path: str | Path) -> DataConfig:
+    with Path(path).open("r", encoding="utf-8") as fh:
+        cfg = yaml.safe_load(fh)
+    return DataConfig(**cfg)
+
+
+def _create_synthetic_raw(root: Path, n_per_class: int = 30, img_size: int = 256) -> None:
+    """Create a minimal synthetic dataset for local testing.
+
+    The generated images contain simple geometric patterns so unit tests have
+    deterministic content to reason about.
+    """
+
+    rng = np.random.default_rng(123)
+    for label in CLASSES:
+        class_dir = ensure_dir(root / "raw" / label)
+        for idx in range(n_per_class):
+            img = np.zeros((img_size, img_size, 3), dtype=np.uint8)
+            color = 255 if label == "tumor" else 100
+            rr, cc = np.ogrid[:img_size, :img_size]
+            center = img_size // 2
+            mask = (rr - center) ** 2 + (cc - center) ** 2 <= (img_size // 4) ** 2
+            img[..., :] = rng.integers(0, 40)
+            img[mask] = color
+            image = Image.fromarray(img, mode="RGB")
+            image.save(class_dir / f"synthetic_{idx:03d}.png")
+
+
+def _load_raw_samples(root: Path) -> List[Tuple[Path, str]]:
+    samples: List[Tuple[Path, str]] = []
+    for label in CLASSES:
+        class_dir = root / "raw" / label
+        if not class_dir.exists():
+            continue
+        for path in sorted(class_dir.glob("*")):
+            if path.suffix.lower() not in {".png", ".jpg", ".jpeg", ".tif", ".tiff"}:
+                continue
+            samples.append((path, label))
+    return samples
+
+
+def _stratified_split(samples: List[Tuple[Path, str]], val: float, test: float) -> Dict[str, List[Tuple[Path, str]]]:
+    rng = random.Random(123)
+    per_class: Dict[str, List[Tuple[Path, str]]] = {label: [] for label in CLASSES}
+    for path, label in samples:
+        per_class[label].append((path, label))
+    for entries in per_class.values():
+        rng.shuffle(entries)
+
+    splits: Dict[str, List[Tuple[Path, str]]] = {"train": [], "val": [], "test": []}
+    for label, entries in per_class.items():
+        n_total = len(entries)
+        n_val = int(round(n_total * val))
+        n_test = int(round(n_total * test))
+        n_train = max(n_total - n_val - n_test, 0)
+        splits["val"].extend(entries[:n_val])
+        splits["test"].extend(entries[n_val:n_val + n_test])
+        splits["train"].extend(entries[n_val + n_test:n_val + n_test + n_train])
+    return splits
+
+
+def _process_and_save(samples: List[Tuple[Path, str]], out_dir: Path, img_size: int) -> List[Dict[str, str]]:
+    manifest_rows: List[Dict[str, str]] = []
+    ensure_dir(out_dir)
+    for src_path, label in samples:
+        image = Image.open(src_path).convert("RGB")
+        image = image.resize((img_size, img_size), Image.BILINEAR)
+        split_dir = ensure_dir(out_dir / label)
+        dst_path = split_dir / src_path.name.replace(src_path.suffix, ".png")
+        image.save(dst_path, format="PNG")
+        manifest_rows.append({
+            "path": str(dst_path),
+            "label": label,
+        })
+    return manifest_rows
+
+
+def prepare_pcam(config_path: str | Path) -> Dict[str, any]:
+    config = load_config(config_path)
+    set_global_seed(123)
+
+    root = ensure_dir(config.root)
+    raw_samples = _load_raw_samples(Path(config.root))
+
+    if not raw_samples:
+        _create_synthetic_raw(Path(config.root), img_size=config.img_size)
+        raw_samples = _load_raw_samples(Path(config.root))
+
+    if not raw_samples:
+        raise RuntimeError("No raw samples found or generated.")
+
+    splits = _stratified_split(raw_samples, config.val_split, config.test_split)
+
+    split_dirs = {
+        "train": ensure_dir(Path(config.root) / "train_images"),
+        "val": ensure_dir(Path(config.root) / "val_images"),
+        "test": ensure_dir(Path(config.root) / "test_images"),
+    }
+
+    manifest: List[Dict[str, str]] = []
+    stats: Dict[str, Dict[str, int]] = {}
+
+    for split_name, split_samples in splits.items():
+        processed = _process_and_save(split_samples, split_dirs[split_name], config.img_size)
+        csv_path = Path(config.root) / f"{split_name}_labels.csv"
+        with csv_path.open("w", newline="", encoding="utf-8") as fh:
+            writer = csv.DictWriter(fh, fieldnames=["path", "label"])
+            writer.writeheader()
+            writer.writerows(processed)
+        manifest.extend({
+            "path": row["path"],
+            "label": row["label"],
+            "split": split_name,
+            "patient_id": "synthetic",
+            "mask_path": "",
+        } for row in processed)
+
+        label_counts: Dict[str, int] = {label: 0 for label in CLASSES}
+        for row in processed:
+            label_counts[row["label"]] += 1
+        stats[split_name] = label_counts
+
+    manifest_path = Path(config.output_csv)
+    ensure_dir(manifest_path.parent)
+    with manifest_path.open("w", newline="", encoding="utf-8") as fh:
+        writer = csv.DictWriter(fh, fieldnames=["path", "label", "split", "patient_id", "mask_path"])
+        writer.writeheader()
+        writer.writerows(manifest)
+
+    write_json({"class_balance": stats}, Path(config.root) / "stats.json")
+
+    return {"manifest": manifest, "stats": stats}
+
+
+__all__ = ["DataConfig", "prepare_pcam", "load_config"]

--- a/synmedvision/src/data/transforms.py
+++ b/synmedvision/src/data/transforms.py
@@ -1,0 +1,42 @@
+"""Basic image transformation utilities used for preprocessing."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable
+
+import numpy as np
+from PIL import Image
+
+
+@dataclass
+class TransformConfig:
+    image_size: int = 256
+    normalize: bool = True
+
+
+class ResizeNormalize:
+    """Resize an image and optionally normalize pixel values."""
+
+    def __init__(self, config: TransformConfig):
+        self.config = config
+
+    def __call__(self, image: Image.Image) -> np.ndarray:
+        resized = image.resize((self.config.image_size, self.config.image_size), Image.BILINEAR)
+        array = np.asarray(resized, dtype=np.float32)
+        if self.config.normalize:
+            array = array / 255.0
+        return array
+
+
+def compose(*funcs: Callable[[Image.Image], np.ndarray]) -> Callable[[Image.Image], np.ndarray]:
+    def _inner(image: Image.Image) -> np.ndarray:
+        result = image
+        for func in funcs:
+            result = func(result)
+        return result
+
+    return _inner
+
+
+__all__ = ["TransformConfig", "ResizeNormalize", "compose"]

--- a/synmedvision/src/demo/streamlit_app.py
+++ b/synmedvision/src/demo/streamlit_app.py
@@ -1,0 +1,106 @@
+"""Streamlit demo for the SynMedVision pipeline."""
+
+from __future__ import annotations
+
+import argparse
+import tempfile
+from pathlib import Path
+from typing import Optional
+
+import streamlit as st
+from PIL import Image
+
+from src.cli.generate import generate_samples
+from src.eval.privacy import privacy_report
+from src.eval.realism import compute_realism_metrics
+from src.eval.utility import compute_utility_metrics
+
+st.set_page_config(page_title="SynMedVision Demo", layout="wide")
+
+
+def _class_mix_string(label: str) -> str:
+    return f"{label}:1.0"
+
+
+def _collect_gallery(paths) -> list[Image.Image]:
+    gallery = []
+    for path in paths[:16]:
+        gallery.append(Image.open(path))
+    return gallery
+
+
+def _save_uploaded_mask(uploaded_file) -> Optional[str]:
+    if uploaded_file is None:
+        return None
+    tmp_dir = Path(tempfile.mkdtemp())
+    mask_path = tmp_dir / uploaded_file.name
+    with mask_path.open("wb") as fh:
+        fh.write(uploaded_file.read())
+    return str(mask_path)
+
+
+def main() -> None:
+    st.sidebar.header("Generation Settings")
+    model = st.sidebar.selectbox("Model", ["Diffusion (LoRA)", "StyleGAN2"], index=0)
+    class_label = st.sidebar.selectbox("Class", ["normal", "tumor"], index=0)
+    n_images = st.sidebar.slider("Number of images", 4, 32, 16, step=4)
+    steps = st.sidebar.slider("Diffusion steps", 10, 100, 30)
+    guidance = st.sidebar.slider("Guidance scale", 1.0, 15.0, 7.5)
+    seed = st.sidebar.number_input("Seed", value=123, step=1)
+    uploaded_mask = st.sidebar.file_uploader("Optional mask", type=["png"])
+
+    out_dir = Path("out/demo_samples")
+    mask_path = _save_uploaded_mask(uploaded_mask)
+
+    if st.sidebar.button("Generate"):
+        args = argparse.Namespace(
+            n=n_images,
+            class_mix=_class_mix_string(class_label),
+            out=str(out_dir),
+            model="diffusion_lora" if model.startswith("Diffusion") else "stylegan2",
+            seed=int(seed),
+            steps=int(steps),
+            guidance=float(guidance),
+            mask_path=mask_path,
+            ckpt=None,
+            base=None,
+        )
+        generated = generate_samples(args)
+        st.session_state["generated_paths"] = [str(p) for p in generated]
+
+    paths = st.session_state.get("generated_paths", [])
+    st.title("SynMedVision Demo")
+
+    if not paths:
+        st.info("Use the sidebar to generate images.")
+        return
+
+    cols = st.columns(4)
+    for idx, image in enumerate(_collect_gallery([Path(p) for p in paths])):
+        with cols[idx % 4]:
+            st.image(image, caption=f"Sample {idx+1}")
+
+    metrics_realism = compute_realism_metrics("data/pcam/val_images", out_dir)
+    metrics_utility = compute_utility_metrics(Path("data/pcam"), out_dir)
+    metrics_privacy = privacy_report("data/pcam/val_images", out_dir, tau=0.3)
+
+    st.subheader("Summary Metrics")
+    col1, col2, col3 = st.columns(3)
+    col1.metric("KID", f"{metrics_realism.get('kid', float('nan')):.4f}")
+    col2.metric("TSTR AUC", f"{metrics_utility.get('tstr', {}).get('roc_auc', float('nan')):.3f}")
+    col3.metric("Privacy risk (%)", f"{metrics_privacy.get('near_duplicate_pct', float('nan')):.2f}")
+
+    tab_realism, tab_utility, tab_privacy = st.tabs(["Realism", "Utility", "Privacy"])
+
+    with tab_realism:
+        st.json(metrics_realism)
+    with tab_utility:
+        st.json(metrics_utility)
+    with tab_privacy:
+        st.json(metrics_privacy)
+
+    st.download_button("Download images manifest", data="\n".join(paths), file_name="synthetic_images.txt")
+
+
+if __name__ == "__main__":
+    main()

--- a/synmedvision/src/eval/privacy.py
+++ b/synmedvision/src/eval/privacy.py
@@ -1,0 +1,114 @@
+"""Privacy related diagnostics for synthetic datasets."""
+
+from __future__ import annotations
+
+import itertools
+from pathlib import Path
+from typing import Dict, Iterable, List, Tuple
+
+import numpy as np
+from PIL import Image
+from imagehash import phash
+from sklearn.linear_model import LogisticRegression
+from sklearn.metrics import roc_auc_score
+from sklearn.metrics.pairwise import cosine_distances
+
+
+def _load_image_features(paths: Iterable[Path], image_size: int = 256) -> np.ndarray:
+    features: List[np.ndarray] = []
+    for path in paths:
+        image = Image.open(path).convert("RGB").resize((image_size, image_size))
+        arr = np.asarray(image, dtype=np.float32) / 255.0
+        features.append(arr.mean(axis=2).flatten())
+    if not features:
+        return np.zeros((0, image_size * image_size))
+    return np.stack(features)
+
+
+def nearest_neighbor_distances(real_dir: str | Path, synth_dir: str | Path, image_size: int = 256) -> Tuple[np.ndarray, np.ndarray]:
+    real_paths = list(Path(real_dir).rglob("*.png"))
+    synth_paths = list(Path(synth_dir).rglob("*.png"))
+
+    real_features = _load_image_features(real_paths, image_size)
+    synth_features = _load_image_features(synth_paths, image_size)
+
+    if real_features.size == 0 or synth_features.size == 0:
+        return np.array([]), np.array([])
+
+    distances = cosine_distances(synth_features, real_features)
+    nearest = distances.min(axis=1)
+    indices = distances.argmin(axis=1)
+    return nearest, indices
+
+
+def find_near_duplicates(real_dir: str | Path, synth_dir: str | Path, tau: float) -> List[Tuple[Path, Path, float]]:
+    nearest, indices = nearest_neighbor_distances(real_dir, synth_dir)
+    if nearest.size == 0:
+        return []
+    real_paths = list(Path(real_dir).rglob("*.png"))
+    synth_paths = list(Path(synth_dir).rglob("*.png"))
+    risky = []
+    for dist, idx_synth, idx_real in zip(nearest, range(len(synth_paths)), indices):
+        if dist <= tau:
+            risky.append((synth_paths[idx_synth], real_paths[idx_real], float(dist)))
+    return risky
+
+
+def membership_inference(real_dir: str | Path, image_size: int = 256) -> float:
+    real_paths = list(Path(real_dir).rglob("*.png"))
+    if len(real_paths) < 4:
+        return float("nan")
+    split = len(real_paths) // 2
+    member_paths = real_paths[:split]
+    non_member_paths = real_paths[split:2 * split]
+
+    member_features = _load_image_features(member_paths, image_size)
+    non_member_features = _load_image_features(non_member_paths, image_size)
+    features = np.concatenate([member_features, non_member_features], axis=0)
+    labels = np.concatenate([np.ones(len(member_features)), np.zeros(len(non_member_features))])
+
+    clf = LogisticRegression(max_iter=200)
+    clf.fit(features, labels)
+    probs = clf.predict_proba(features)[:, 1]
+    return float(roc_auc_score(labels, probs))
+
+
+def phash_duplicates(real_dir: str | Path, synth_dir: str | Path, threshold: int = 6) -> List[Tuple[Path, Path, int]]:
+    def hash_directory(directory: Path) -> List[Tuple[Path, any]]:
+        hashes = []
+        for path in directory.rglob("*.png"):
+            hashes.append((path, phash(Image.open(path))))
+        return hashes
+
+    real_hashes = hash_directory(Path(real_dir))
+    synth_hashes = hash_directory(Path(synth_dir))
+
+    duplicates: List[Tuple[Path, Path, int]] = []
+    for (path_s, hash_s), (path_r, hash_r) in itertools.product(synth_hashes, real_hashes):
+        dist = hash_s - hash_r
+        if dist <= threshold:
+            duplicates.append((path_s, path_r, int(dist)))
+    return duplicates
+
+
+def privacy_report(real_dir: str | Path, synth_dir: str | Path, tau: float, phash_threshold: int = 6) -> Dict[str, any]:
+    nearest, _ = nearest_neighbor_distances(real_dir, synth_dir)
+    duplicates = phash_duplicates(real_dir, synth_dir, phash_threshold)
+    membership_auc = membership_inference(real_dir)
+    risky = np.mean(nearest <= tau) * 100 if nearest.size else float("nan")
+    return {
+        "nn_min": float(nearest.min()) if nearest.size else float("nan"),
+        "nn_mean": float(nearest.mean()) if nearest.size else float("nan"),
+        "near_duplicate_pct": float(risky),
+        "membership_auc": membership_auc,
+        "phash_duplicates": duplicates,
+    }
+
+
+__all__ = [
+    "nearest_neighbor_distances",
+    "find_near_duplicates",
+    "membership_inference",
+    "phash_duplicates",
+    "privacy_report",
+]

--- a/synmedvision/src/eval/realism.py
+++ b/synmedvision/src/eval/realism.py
@@ -1,0 +1,128 @@
+"""Lightweight image realism and diversity metrics."""
+
+from __future__ import annotations
+
+import math
+from pathlib import Path
+from typing import Dict, Iterable, Tuple
+
+import numpy as np
+from PIL import Image
+from scipy import linalg
+
+from src.common.fs import ensure_dir
+
+
+def _list_image_paths(directory: str | Path) -> Iterable[Path]:
+    directory = Path(directory)
+    if not directory.exists():
+        return []
+    for path in directory.rglob("*.png"):
+        yield path
+
+
+def _load_image(path: Path, image_size: int) -> np.ndarray:
+    image = Image.open(path).convert("RGB").resize((image_size, image_size))
+    return np.asarray(image, dtype=np.float32) / 255.0
+
+
+def _extract_features(images: Iterable[np.ndarray]) -> np.ndarray:
+    feats = []
+    for img in images:
+        pooled = img.mean(axis=2)
+        downsampled = pooled[::8, ::8]
+        feats.append(downsampled.flatten())
+    if not feats:
+        return np.zeros((0, 1), dtype=np.float32)
+    return np.stack(feats)
+
+
+def polynomial_mmd(x: np.ndarray, y: np.ndarray, degree: int = 3, gamma: float = 1.0, coef0: float = 1.0) -> float:
+    def kernel(a: np.ndarray, b: np.ndarray) -> np.ndarray:
+        return (gamma * a @ b.T + coef0) ** degree
+
+    k_xx = kernel(x, x)
+    k_yy = kernel(y, y)
+    k_xy = kernel(x, y)
+    return float(k_xx.mean() + k_yy.mean() - 2 * k_xy.mean())
+
+
+def compute_kid(real: np.ndarray, synth: np.ndarray) -> float:
+    if len(real) == 0 or len(synth) == 0:
+        return float("nan")
+    return polynomial_mmd(real, synth)
+
+
+def compute_fid(real: np.ndarray, synth: np.ndarray) -> float:
+    if len(real) == 0 or len(synth) == 0:
+        return float("nan")
+    mu_r, mu_s = real.mean(axis=0), synth.mean(axis=0)
+    cov_r = np.cov(real, rowvar=False)
+    cov_s = np.cov(synth, rowvar=False)
+    covmean = linalg.sqrtm(cov_r @ cov_s)
+    if np.iscomplexobj(covmean):
+        covmean = covmean.real
+    diff = mu_r - mu_s
+    fid = diff @ diff + np.trace(cov_r + cov_s - 2 * covmean)
+    return float(np.real(fid))
+
+
+def compute_lpips(real_images: np.ndarray, synth_images: np.ndarray) -> float:
+    if len(real_images) == 0 or len(synth_images) == 0:
+        return float("nan")
+    n = min(len(real_images), len(synth_images))
+    diffs = []
+    for idx in range(n):
+        diffs.append(np.mean(np.abs(real_images[idx] - synth_images[idx])))
+    return float(np.mean(diffs))
+
+
+def covariance_rank_ratio(real: np.ndarray, synth: np.ndarray) -> float:
+    if real.size == 0 or synth.size == 0:
+        return float("nan")
+    cov_real = np.cov(real, rowvar=False)
+    cov_synth = np.cov(synth, rowvar=False)
+    rank_real = np.linalg.matrix_rank(cov_real)
+    rank_synth = np.linalg.matrix_rank(cov_synth)
+    if rank_real == 0:
+        return float("nan")
+    return float(rank_synth / rank_real)
+
+
+def feature_entropy(features: np.ndarray, bins: int = 32) -> float:
+    if features.size == 0:
+        return float("nan")
+    hist, _ = np.histogram(features, bins=bins, density=True)
+    hist = hist[hist > 0]
+    return float(-np.sum(hist * np.log(hist + 1e-12)))
+
+
+def compute_realism_metrics(real_dir: str | Path, synth_dir: str | Path, image_size: int = 256) -> Dict[str, float]:
+    real_paths = list(_list_image_paths(real_dir))
+    synth_paths = list(_list_image_paths(synth_dir))
+
+    real_images = np.array([_load_image(p, image_size) for p in real_paths]) if real_paths else np.zeros((0, image_size, image_size, 3))
+    synth_images = np.array([_load_image(p, image_size) for p in synth_paths]) if synth_paths else np.zeros((0, image_size, image_size, 3))
+
+    real_features = _extract_features(real_images)
+    synth_features = _extract_features(synth_images)
+
+    metrics = {
+        "kid": compute_kid(real_features, synth_features),
+        "fid": compute_fid(real_features, synth_features),
+        "lpips": compute_lpips(real_images, synth_images),
+        "feature_entropy_real": feature_entropy(real_features.flatten()),
+        "feature_entropy_synth": feature_entropy(synth_features.flatten()),
+        "cov_rank_ratio": covariance_rank_ratio(real_features, synth_features),
+    }
+    return metrics
+
+
+__all__ = [
+    "compute_realism_metrics",
+    "compute_kid",
+    "compute_fid",
+    "compute_lpips",
+    "feature_entropy",
+    "covariance_rank_ratio",
+]

--- a/synmedvision/src/eval/report.py
+++ b/synmedvision/src/eval/report.py
@@ -1,0 +1,51 @@
+"""Generate HTML reports summarising evaluation metrics."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict
+
+from jinja2 import Template
+
+from src.common.fs import ensure_dir
+
+
+TEMPLATE = Template(
+    """<!DOCTYPE html>
+<html lang=\"en\">
+<head>
+  <meta charset=\"utf-8\" />
+  <title>SynMedVision Evaluation Report</title>
+  <style>
+    body { font-family: Arial, sans-serif; margin: 2rem; }
+    h1 { color: #2b7a78; }
+    table { border-collapse: collapse; margin-bottom: 2rem; }
+    th, td { border: 1px solid #ccc; padding: 0.5rem 0.75rem; }
+    th { background: #def2f1; }
+  </style>
+</head>
+<body>
+  <h1>SynMedVision Evaluation Report</h1>
+  {% for section, values in metrics.items() %}
+  <h2>{{ section|title }}</h2>
+  <table>
+    <tr><th>Metric</th><th>Value</th></tr>
+    {% for key, value in values.items() %}
+    <tr><td>{{ key }}</td><td>{{ value }}</td></tr>
+    {% endfor %}
+  </table>
+  {% endfor %}
+</body>
+</html>
+"""
+)
+
+
+def generate_report(metrics: Dict[str, Dict[str, Any]], out_path: str | Path) -> Path:
+    out_path = Path(out_path)
+    ensure_dir(out_path.parent)
+    out_path.write_text(TEMPLATE.render(metrics=metrics), encoding="utf-8")
+    return out_path
+
+
+__all__ = ["generate_report"]

--- a/synmedvision/src/eval/utility.py
+++ b/synmedvision/src/eval/utility.py
@@ -1,0 +1,105 @@
+"""Utility metrics comparing synthetic and real datasets."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Iterable, Tuple
+
+import numpy as np
+from PIL import Image
+from sklearn.linear_model import LogisticRegression
+from sklearn.metrics import accuracy_score, average_precision_score, roc_auc_score
+
+
+@dataclass
+class Dataset:
+    features: np.ndarray
+    labels: np.ndarray
+
+
+CLASS_TO_INT = {"normal": 0, "tumor": 1}
+
+
+def _load_image(path: Path, image_size: int) -> np.ndarray:
+    image = Image.open(path).convert("RGB").resize((image_size, image_size))
+    arr = np.asarray(image, dtype=np.float32) / 255.0
+    return arr.mean(axis=2).flatten()
+
+
+def _load_from_csv(csv_path: Path, image_size: int) -> Dataset:
+    if not csv_path.exists():
+        return Dataset(features=np.zeros((0, image_size * image_size)), labels=np.zeros((0,)))
+    paths: list[str] = []
+    labels: list[int] = []
+    with csv_path.open("r", encoding="utf-8") as fh:
+        header = fh.readline().strip().split(",")
+        for line in fh:
+            row = dict(zip(header, line.strip().split(",")))
+            paths.append(row["path"])
+            labels.append(CLASS_TO_INT[row["label"]])
+    features = np.stack([_load_image(Path(p), image_size) for p in paths]) if paths else np.zeros((0, image_size * image_size))
+    return Dataset(features=features, labels=np.array(labels, dtype=np.int32))
+
+
+def _load_from_directory(directory: Path, image_size: int) -> Dataset:
+    features: list[np.ndarray] = []
+    labels: list[int] = []
+    for label_name, label_idx in CLASS_TO_INT.items():
+        label_dir = directory / label_name
+        if not label_dir.exists():
+            continue
+        for path in sorted(label_dir.glob("*.png")):
+            features.append(_load_image(path, image_size))
+            labels.append(label_idx)
+    if not features:
+        return Dataset(features=np.zeros((0, image_size * image_size)), labels=np.zeros((0,)))
+    return Dataset(features=np.stack(features), labels=np.array(labels, dtype=np.int32))
+
+
+def _train_classifier(dataset: Dataset) -> LogisticRegression:
+    if dataset.features.shape[0] == 0:
+        raise ValueError("Empty dataset provided to classifier training")
+    clf = LogisticRegression(max_iter=200)
+    clf.fit(dataset.features, dataset.labels)
+    return clf
+
+
+def _evaluate(clf: LogisticRegression, dataset: Dataset) -> Dict[str, float]:
+    if dataset.features.shape[0] == 0:
+        return {"accuracy": float("nan"), "roc_auc": float("nan"), "pr_auc": float("nan")}
+    probs = clf.predict_proba(dataset.features)[:, 1]
+    preds = (probs >= 0.5).astype(int)
+    return {
+        "accuracy": float(accuracy_score(dataset.labels, preds)),
+        "roc_auc": float(roc_auc_score(dataset.labels, probs)),
+        "pr_auc": float(average_precision_score(dataset.labels, probs)),
+    }
+
+
+def compute_utility_metrics(data_root: str | Path, synth_dir: str | Path, image_size: int = 256) -> Dict[str, Dict[str, float]]:
+    data_root = Path(data_root)
+    synth_dir = Path(synth_dir)
+
+    train_dataset = _load_from_csv(data_root / "train_labels.csv", image_size)
+    val_dataset = _load_from_csv(data_root / "val_labels.csv", image_size)
+    synth_dataset = _load_from_directory(synth_dir, image_size)
+
+    metrics: Dict[str, Dict[str, float]] = {}
+
+    if synth_dataset.features.size and val_dataset.features.size:
+        clf_synth = _train_classifier(synth_dataset)
+        metrics["tstr"] = _evaluate(clf_synth, val_dataset)
+    else:
+        metrics["tstr"] = {"accuracy": float("nan"), "roc_auc": float("nan"), "pr_auc": float("nan")}
+
+    if train_dataset.features.size and synth_dataset.features.size:
+        clf_real = _train_classifier(train_dataset)
+        metrics["trts"] = _evaluate(clf_real, synth_dataset)
+    else:
+        metrics["trts"] = {"accuracy": float("nan"), "roc_auc": float("nan"), "pr_auc": float("nan")}
+
+    return metrics
+
+
+__all__ = ["compute_utility_metrics"]

--- a/synmedvision/src/models/controlnet/condition.py
+++ b/synmedvision/src/models/controlnet/condition.py
@@ -1,0 +1,35 @@
+"""Utility helpers for optional mask based conditioning."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+from PIL import Image
+
+from src.common.fs import ensure_dir
+
+
+def prepare_mask(mask_path: str | Path, image_size: int = 256) -> np.ndarray:
+    """Load a binary mask and resize to match the generation size."""
+
+    mask = Image.open(mask_path).convert("L").resize((image_size, image_size))
+    return (np.asarray(mask, dtype=np.float32) / 255.0) > 0.5
+
+
+def apply_mask_to_image(image: np.ndarray, mask: np.ndarray, color: tuple[int, int, int] = (255, 0, 0)) -> np.ndarray:
+    overlay = image.copy()
+    for channel, value in enumerate(color):
+        overlay[..., channel] = np.where(mask, value / 255.0, overlay[..., channel])
+    return overlay
+
+
+def save_conditioning(mask: np.ndarray, out_dir: str | Path, name: str) -> Path:
+    ensure_dir(out_dir)
+    image = Image.fromarray((mask.astype(np.float32) * 255).astype(np.uint8))
+    path = Path(out_dir) / f"{name}.png"
+    image.save(path)
+    return path
+
+
+__all__ = ["prepare_mask", "apply_mask_to_image", "save_conditioning"]

--- a/synmedvision/src/models/diffusion/finetune_lora.py
+++ b/synmedvision/src/models/diffusion/finetune_lora.py
@@ -1,0 +1,65 @@
+"""Mock diffusion LoRA fine-tuning implementation."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict
+
+import json
+import numpy as np
+
+from src.common.fs import ensure_dir, write_json
+from src.common.seed import set_global_seed
+
+
+class DummyDiffusion:
+    def __init__(self, latent_dim: int = 64):
+        self.latent_dim = latent_dim
+        rng = np.random.default_rng(321)
+        self.weights = rng.standard_normal((latent_dim, latent_dim))
+
+    def forward(self, x: np.ndarray) -> np.ndarray:
+        return x @ self.weights
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {"latent_dim": self.latent_dim, "weights": self.weights.tolist()}
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "DummyDiffusion":
+        obj = cls(latent_dim=int(data["latent_dim"]))
+        obj.weights = np.asarray(data["weights"], dtype=np.float32)
+        return obj
+
+
+def _save_checkpoint(model: DummyDiffusion, path: Path) -> None:
+    tmp_path = path.with_suffix(path.suffix + ".json")
+    tmp_path.write_text(json.dumps(model.to_dict()))
+    tmp_path.replace(path)
+
+
+def _load_checkpoint(path: Path) -> DummyDiffusion:
+    data = json.loads(Path(path).read_text())
+    return DummyDiffusion.from_dict(data)
+
+
+def finetune_lora(config: Dict[str, Any]) -> Path:
+    set_global_seed(int(config.get("seed", 123)))
+    out_dir = ensure_dir(config.get("out_dir", "out/diffusion_lora"))
+
+    model = DummyDiffusion()
+    rng = np.random.default_rng(321)
+    inputs = rng.standard_normal((16, model.latent_dim))
+    targets = np.zeros_like(inputs)
+    outputs = model.forward(inputs)
+    loss = float(np.mean((outputs - targets) ** 2))
+
+    grad = outputs - targets
+    model.weights -= 0.001 * inputs.T @ grad / len(inputs)
+
+    ckpt_path = out_dir / "lora.pt"
+    _save_checkpoint(model, ckpt_path)
+    write_json({"loss": loss, "epsilon": float(config.get("dp", {}).get("target_epsilon", 10))}, out_dir / "train_log.json")
+    return ckpt_path
+
+
+__all__ = ["finetune_lora", "DummyDiffusion", "_load_checkpoint"]

--- a/synmedvision/src/models/diffusion/sample.py
+++ b/synmedvision/src/models/diffusion/sample.py
@@ -1,0 +1,95 @@
+"""Sampling utilities for the dummy diffusion pipeline."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from typing import Iterable, Optional
+
+import numpy as np
+from PIL import Image
+
+from src.common.fs import ensure_dir
+from src.common.seed import set_global_seed
+from src.models.diffusion.finetune_lora import DummyDiffusion, _load_checkpoint
+
+
+def load_model(base: str | Path) -> DummyDiffusion:
+    ckpt_path = Path(base) / "lora.pt"
+    return _load_checkpoint(ckpt_path)
+
+
+def _apply_mask_overlay(image: np.ndarray, mask_path: Optional[str]) -> np.ndarray:
+    if not mask_path:
+        return image
+    mask_img = Image.open(mask_path).convert("L").resize(image.shape[:2][::-1])
+    mask = np.asarray(mask_img, dtype=np.float32) / 255.0
+    overlay = image.copy()
+    overlay[..., 0] = np.clip(overlay[..., 0] * (0.5 + 0.5 * mask), 0, 255)
+    return overlay
+
+
+def sample_images(
+    base: str | Path,
+    n: int,
+    class_label: str,
+    steps: int = 30,
+    guidance: float = 7.5,
+    seed: int = 123,
+    out: str | Path = "out/samples",
+    mask_path: Optional[str] = None,
+) -> Iterable[Path]:
+    set_global_seed(seed)
+    model = load_model(base)
+
+    out_dir = ensure_dir(Path(out) / class_label)
+    rng = np.random.default_rng(seed)
+    latents = rng.standard_normal((n, model.latent_dim))
+    features = model.forward(latents)
+    features = np.tanh(features)
+    features = features.reshape(n, 8, 8, -1).mean(axis=-1)
+
+    saved_paths = []
+    for idx, feat in enumerate(features):
+        array = feat - feat.min()
+        array = 255 * array / (array.max() + 1e-8)
+        array = np.asarray(Image.fromarray(array.astype(np.uint8)).resize((256, 256)), dtype=np.float32)
+        rgb = np.stack([array, np.flipud(array), np.roll(array, 5, axis=0)], axis=-1)
+        rgb = _apply_mask_overlay(rgb, mask_path)
+        image = Image.fromarray(np.clip(rgb, 0, 255).astype(np.uint8))
+        path = out_dir / f"{class_label}_{idx:05d}.png"
+        image.save(path)
+        saved_paths.append(path)
+    return saved_paths
+
+
+def build_argparser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Sample images from the dummy diffusion pipeline")
+    parser.add_argument("--base", required=True)
+    parser.add_argument("--n", type=int, required=True)
+    parser.add_argument("--class", dest="class_label", required=True)
+    parser.add_argument("--steps", type=int, default=30)
+    parser.add_argument("--guidance", type=float, default=7.5)
+    parser.add_argument("--seed", type=int, default=123)
+    parser.add_argument("--out", required=True)
+    parser.add_argument("--mask_path")
+    return parser
+
+
+def main(args: Optional[list[str]] = None) -> None:
+    parser = build_argparser()
+    parsed = parser.parse_args(args=args)
+    sample_images(
+        base=parsed.base,
+        n=parsed.n,
+        class_label=parsed.class_label,
+        steps=parsed.steps,
+        guidance=parsed.guidance,
+        seed=parsed.seed,
+        out=parsed.out,
+        mask_path=parsed.mask_path,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/synmedvision/src/models/stylegan2/sample.py
+++ b/synmedvision/src/models/stylegan2/sample.py
@@ -1,0 +1,74 @@
+"""Sampling utilities for the dummy StyleGAN2 model."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from typing import Iterable
+
+import numpy as np
+from PIL import Image
+
+from src.common.fs import ensure_dir
+from src.common.seed import set_global_seed
+from src.models.stylegan2.train import DummyStyleGAN2, _load_checkpoint
+
+
+def load_generator(ckpt_path: str | Path) -> DummyStyleGAN2:
+    return _load_checkpoint(Path(ckpt_path))
+
+
+def _upsample(feature: np.ndarray) -> np.ndarray:
+    image = Image.fromarray(feature.astype(np.uint8))
+    return np.asarray(image.resize((256, 256), Image.BILINEAR), dtype=np.uint8)
+
+
+def sample_images(
+    ckpt_path: str | Path,
+    n: int,
+    class_label: str,
+    out_dir: str | Path,
+    seed: int = 123,
+) -> Iterable[Path]:
+    set_global_seed(seed)
+    generator = load_generator(ckpt_path)
+
+    out_path = ensure_dir(Path(out_dir) / class_label)
+    rng = np.random.default_rng(seed)
+    latents = rng.standard_normal((n, generator.latent_dim))
+    outputs = generator.forward(latents)
+    outputs = outputs.reshape(n, 3, 16, 16)
+
+    saved_paths = []
+    for idx, tensor in enumerate(outputs):
+        channels = []
+        for channel in tensor:
+            channel = channel - channel.min()
+            channel = 255 * channel / (channel.max() + 1e-8)
+            channels.append(_upsample(channel))
+        array = np.stack(channels, axis=-1)
+        image = Image.fromarray(array.astype(np.uint8))
+        file_path = out_path / f"{class_label}_{idx:05d}.png"
+        image.save(file_path)
+        saved_paths.append(file_path)
+    return saved_paths
+
+
+def build_argparser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Sample images from a dummy StyleGAN2 checkpoint")
+    parser.add_argument("--ckpt", required=True)
+    parser.add_argument("--n", type=int, required=True)
+    parser.add_argument("--class", dest="class_label", required=True)
+    parser.add_argument("--out", required=True)
+    parser.add_argument("--seed", type=int, default=123)
+    return parser
+
+
+def main(args: argparse.Namespace | None = None) -> None:
+    parser = build_argparser()
+    parsed = parser.parse_args(args=args)
+    sample_images(parsed.ckpt, parsed.n, parsed.class_label, parsed.out, parsed.seed)
+
+
+if __name__ == "__main__":
+    main()

--- a/synmedvision/src/models/stylegan2/train.py
+++ b/synmedvision/src/models/stylegan2/train.py
@@ -1,0 +1,73 @@
+"""Placeholder StyleGAN2 training loop used for local testing."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict
+
+import json
+import numpy as np
+
+from src.common.fs import ensure_dir, write_json
+from src.common.seed import set_global_seed
+
+
+class DummyStyleGAN2:
+    """A minimal generator implemented with NumPy."""
+
+    def __init__(self, latent_dim: int = 32):
+        self.latent_dim = latent_dim
+        rng = np.random.default_rng(123)
+        self.weights = rng.standard_normal((latent_dim, 3 * 16 * 16))
+        self.bias = rng.standard_normal(3 * 16 * 16)
+
+    def forward(self, z: np.ndarray) -> np.ndarray:
+        return z @ self.weights + self.bias
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {"latent_dim": self.latent_dim, "weights": self.weights.tolist(), "bias": self.bias.tolist()}
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "DummyStyleGAN2":
+        obj = cls(latent_dim=int(data["latent_dim"]))
+        obj.weights = np.asarray(data["weights"], dtype=np.float32)
+        obj.bias = np.asarray(data["bias"], dtype=np.float32)
+        return obj
+
+
+def _save_checkpoint(model: DummyStyleGAN2, path: Path) -> None:
+    tmp_path = path.with_suffix(path.suffix + ".json")
+    tmp_path.write_text(json.dumps(model.to_dict()))
+    tmp_path.replace(path)
+
+
+def _load_checkpoint(path: Path) -> DummyStyleGAN2:
+    data = json.loads(Path(path).read_text())
+    return DummyStyleGAN2.from_dict(data)
+
+
+def train_stylegan2(config: Dict[str, Any]) -> Path:
+    """Create a deterministic mock checkpoint without relying on torch."""
+
+    set_global_seed(int(config.get("seed", 123)))
+    out_dir = ensure_dir(config.get("out_dir", "out/stylegan2"))
+
+    model = DummyStyleGAN2()
+    rng = np.random.default_rng(123)
+    latents = rng.standard_normal((8, model.latent_dim))
+    target = np.zeros((8, 3 * 16 * 16), dtype=np.float32)
+    outputs = model.forward(latents)
+    loss = float(np.mean((outputs - target) ** 2))
+
+    # Single gradient-like update to modify weights
+    grad = (outputs - target)
+    model.weights -= 0.001 * latents.T @ grad / len(latents)
+    model.bias -= 0.001 * grad.mean(axis=0)
+
+    ckpt_path = out_dir / "ckpt.pt"
+    _save_checkpoint(model, ckpt_path)
+    write_json({"loss": loss}, out_dir / "train_log.json")
+    return ckpt_path
+
+
+__all__ = ["train_stylegan2", "DummyStyleGAN2", "_load_checkpoint"]

--- a/synmedvision/tests/conftest.py
+++ b/synmedvision/tests/conftest.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/synmedvision/tests/test_eval_metrics.py
+++ b/synmedvision/tests/test_eval_metrics.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+from PIL import Image
+
+from src.eval.realism import compute_realism_metrics
+from src.eval.utility import compute_utility_metrics
+
+
+def _create_image(directory: Path, name: str, intensity: float) -> None:
+    array = np.full((256, 256, 3), fill_value=intensity, dtype=np.uint8)
+    Image.fromarray(array).save(directory / f"{name}.png")
+
+
+def test_realism_metrics_return_finite_values(tmp_path: Path) -> None:
+    real_dir = tmp_path / "real"
+    synth_dir = tmp_path / "synth"
+    real_dir.mkdir()
+    synth_dir.mkdir()
+
+    for idx in range(10):
+        _create_image(real_dir, f"real_{idx}", intensity=50 + idx)
+        _create_image(synth_dir, f"synth_{idx}", intensity=100 + idx)
+
+    metrics = compute_realism_metrics(real_dir, synth_dir)
+    assert np.isfinite(metrics["kid"])
+    assert np.isfinite(metrics["fid"])
+    assert np.isfinite(metrics["lpips"])
+
+
+def test_utility_metrics_pipeline(tmp_path: Path) -> None:
+    data_root = tmp_path / "data"
+    synth_dir = tmp_path / "synth"
+    (data_root / "train_images" / "normal").mkdir(parents=True, exist_ok=True)
+    (data_root / "train_images" / "tumor").mkdir(parents=True, exist_ok=True)
+    (data_root / "val_images" / "normal").mkdir(parents=True, exist_ok=True)
+    (data_root / "val_images" / "tumor").mkdir(parents=True, exist_ok=True)
+    (synth_dir / "normal").mkdir(parents=True, exist_ok=True)
+    (synth_dir / "tumor").mkdir(parents=True, exist_ok=True)
+
+    def write_split(split: str, base_intensity: int) -> None:
+        rows = ["path,label\n"]
+        for idx in range(10):
+            label = "normal" if idx % 2 == 0 else "tumor"
+            path = data_root / f"{split}_images" / label / f"img_{idx}.png"
+            _create_image(path.parent, f"img_{idx}", intensity=base_intensity + idx * 5)
+            rows.append(f"{path},{label}\n")
+        (data_root / f"{split}_labels.csv").write_text("".join(rows), encoding="utf-8")
+
+    write_split("train", 30)
+    write_split("val", 60)
+
+    for idx in range(10):
+        label = "normal" if idx % 2 == 0 else "tumor"
+        _create_image(synth_dir / label, f"synth_{idx}", intensity=80 + idx * 3)
+
+    metrics = compute_utility_metrics(data_root, synth_dir)
+    assert "tstr" in metrics and "trts" in metrics
+    for section in metrics.values():
+        for value in section.values():
+            assert np.isfinite(value)

--- a/synmedvision/tests/test_io.py
+++ b/synmedvision/tests/test_io.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import csv
+from pathlib import Path
+
+from PIL import Image
+
+from src.cli.generate import generate_samples
+from src.data.prepare_pcam import prepare_pcam
+from src.models.diffusion.finetune_lora import finetune_lora
+from src.models.stylegan2.train import train_stylegan2
+
+
+def _write_config(tmp_path: Path) -> Path:
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(
+        """
+        dataset: "pcam"
+        root: "{root}"
+        img_size: 256
+        val_split: 0.2
+        test_split: 0.2
+        split_by_patient: false
+        make_masks: false
+        normalize:
+          method: "none"
+        output_csv: "{root}/manifest.csv"
+        """.replace("{root}", str(tmp_path / "pcam")),
+        encoding="utf-8",
+    )
+    return config_path
+
+
+def test_prepare_pcam_outputs_expected_structure(tmp_path: Path) -> None:
+    config_path = _write_config(tmp_path)
+    prepare_pcam(config_path)
+    root = tmp_path / "pcam"
+
+    for split in ["train_images", "val_images", "test_images"]:
+        for image_path in (root / split / "normal").glob("*.png"):
+            with Image.open(image_path) as img:
+                assert img.size == (256, 256)
+                assert img.mode == "RGB"
+
+    manifest_path = root / "manifest.csv"
+    assert manifest_path.exists()
+    with manifest_path.open("r", encoding="utf-8") as fh:
+        reader = csv.DictReader(fh)
+        row = next(reader)
+        assert set(row.keys()) == {"path", "label", "split", "patient_id", "mask_path"}
+
+
+def test_generate_samples_creates_manifest(tmp_path: Path) -> None:
+    config_path = _write_config(tmp_path)
+    prepare_pcam(config_path)
+
+    stylegan_ckpt = train_stylegan2({"out_dir": tmp_path / "out/stylegan2", "seed": 123})
+    finetune_lora({"out_dir": tmp_path / "out/diffusion_lora", "seed": 123})
+
+    args = type("Args", (), {
+        "n": 10,
+        "class_mix": "normal:0.5,tumor:0.5",
+        "out": str(tmp_path / "samples"),
+        "model": "stylegan2",
+        "seed": 123,
+        "steps": 30,
+        "guidance": 7.5,
+        "mask_path": None,
+        "ckpt": str(stylegan_ckpt),
+        "base": str(tmp_path / "out/diffusion_lora"),
+    })
+
+    paths = list(generate_samples(args))
+    assert len(paths) == 10
+    manifest_path = Path(args.out) / "manifest.csv"
+    assert manifest_path.exists()
+
+    with manifest_path.open("r", encoding="utf-8") as fh:
+        reader = csv.DictReader(fh)
+        rows = list(reader)
+    assert len(rows) == 10
+    assert set(rows[0].keys()) == {"path", "class", "seed", "model", "params"}

--- a/synmedvision/tests/test_privacy.py
+++ b/synmedvision/tests/test_privacy.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+from PIL import Image
+
+from src.eval.privacy import membership_inference, nearest_neighbor_distances, phash_duplicates
+
+
+def _create_image(path: Path, value: int) -> None:
+    array = np.full((256, 256, 3), value, dtype=np.uint8)
+    Image.fromarray(array).save(path)
+
+
+def test_nearest_neighbor_distance_range(tmp_path: Path) -> None:
+    real_dir = tmp_path / "real"
+    synth_dir = tmp_path / "synth"
+    real_dir.mkdir()
+    synth_dir.mkdir()
+
+    for idx in range(4):
+        _create_image(real_dir / f"real_{idx}.png", 30 + idx)
+        _create_image(synth_dir / f"synth_{idx}.png", 60 + idx)
+
+    distances, indices = nearest_neighbor_distances(real_dir, synth_dir)
+    assert distances.size == 4
+    assert np.all(distances >= 0) and np.all(distances <= 2)
+
+
+def test_phash_duplicates_detects_match(tmp_path: Path) -> None:
+    real_dir = tmp_path / "real"
+    synth_dir = tmp_path / "synth"
+    real_dir.mkdir()
+    synth_dir.mkdir()
+
+    _create_image(real_dir / "real.png", 100)
+    _create_image(synth_dir / "synth.png", 100)
+
+    duplicates = phash_duplicates(real_dir, synth_dir, threshold=1)
+    assert duplicates, "Expected duplicate pair to be identified"
+
+
+def test_membership_inference_auc_returns_value(tmp_path: Path) -> None:
+    real_dir = tmp_path / "real"
+    real_dir.mkdir()
+    for idx in range(10):
+        _create_image(real_dir / f"img_{idx}.png", 40 + idx)
+
+    auc = membership_inference(real_dir)
+    assert 0.0 <= auc <= 1.0


### PR DESCRIPTION
## Summary
- document the SynMedVision project layout, dependencies, and automation entry points
- implement synthetic PCam preparation, lightweight StyleGAN2/diffusion placeholders, evaluation utilities, and Streamlit demo support
- add regression tests covering dataset IO, evaluation metrics, and privacy helpers

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68cf691906a48328999c5602da25b090