### PR TITLE
Ensure streamlit demo can locate package

### DIFF
--- a/synmedvision/src/demo/streamlit_app.py
+++ b/synmedvision/src/demo/streamlit_app.py
@@ -3,12 +3,18 @@
 from __future__ import annotations
 
 import argparse
+import sys
 import tempfile
 from pathlib import Path
 from typing import Optional
 
 import streamlit as st
 from PIL import Image
+
+repo_root = Path(__file__).resolve().parents[2]
+repo_root_str = str(repo_root)
+if repo_root_str not in sys.path:
+    sys.path.append(repo_root_str)
 
 from src.cli.generate import generate_samples
 from src.eval.privacy import privacy_report


### PR DESCRIPTION
## Summary
- add a sys.path fallback so the Streamlit demo can import the local `src` package when the project is not installed

## Testing
- streamlit run src/demo/streamlit_app.py --server.headless true --server.port 8502

------
https://chatgpt.com/codex/tasks/task_e_68cf73ee1f7083289a8a312408e9aaa9